### PR TITLE
Added new command and extended two others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ target/*
 
 # Test config
 SquishyYaml/src/main/resources/test.yaml
-/target/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ target/*
 
 # Test config
 SquishyYaml/src/main/resources/test.yaml
+/target/

--- a/src/main/resources/commands.yml
+++ b/src/main/resources/commands.yml
@@ -83,6 +83,16 @@ commands:
         header: '&7[&f%amount%&7] &c&lAdmins'
         # Placeholders will parse in terms of the player.
         section: '&7- &f<player> {server_formatted}'
+      mod:
+        permission: "leaf.rank.mod"
+        header: '&7[&f%amount%&7] &c&lMods'
+        # Placeholders will parse in terms of the player.
+        section: '&7- &f<player> {server_formatted}'
+      help:
+        permission: "leaf.rank.helper"
+        header: '&7[&f%amount%&7] &c&lHelpers'
+        # Placeholders will parse in terms of the player.
+        section: '&7- &f<player> {server_formatted}'
 
   reload:
     type: "reload"
@@ -216,6 +226,36 @@ commands:
     # %page_amount% : The amount of pages they can see.Trfor (int i = 0; i< n;i++){
     footer: '&8&m&l---------------------'
 
+  amenu:
+    type: "inventory"
+    enabled: true
+    name: "amenu"
+    permission: "leaf.amenu"
+    error: "{error_colour}Error occurred when opening admin menu."
+    inventory:
+      size: GENERIC_9X6
+      title: "&8&lAdmin Menu"
+      content:
+        "top,bottom":
+          material: RED_STAINED_GLASS_PANE
+        "center0":
+          skull: "<player>"
+          name: "&a&l<player>"
+          lore:
+            - "&7Welcome Admin!"
+        "19":
+          material: "black_banner"
+          name: "&a&lToggle Spy"
+          commands:
+            # Only works with commands registered with this plugin.
+            - "togglespy"
+        "21":
+          material: "name_tag"
+          name: "&a&lShow Stafflist"
+          commands:
+            # Only works with commands registered with this plugin.
+            - "stafflist"
+
   inventory:
     type: "inventory"
     enabled: true
@@ -225,13 +265,25 @@ commands:
       size: GENERIC_9X6
       title: "&8&lMenu"
       content:
-        "top,bottom":
-          material: LIME_STAINED_GLASS_PANE
+        "top":
+          material: GRAY_STAINED_GLASS_PANE
         "center0":
           skull: "<player>"
           name: "&a&l<player>"
           lore:
             - "&7You are amazing!"
+        "8":
+          material: "end_crystal"
+          name: "&a&lFriends Settings"
+          commands:
+            # Only works with commands registered with this plugin.
+            - "friends settings"
+        "10":
+          material: "writable_book"
+          name: "&a&lView your friends list"
+          commands:
+            # Only works with commands registered with this plugin.
+            - "friends list"
         "center1":
           material: "Paper"
           name: "&a&lRun Command &f/servers"

--- a/src/main/resources/commands.yml
+++ b/src/main/resources/commands.yml
@@ -267,7 +267,7 @@ commands:
       size: GENERIC_9X6
       title: "&8&lMenu"
       content:
-        "top":
+        "top,bottom":
           material: GRAY_STAINED_GLASS_PANE
         "center0":
           # Sets the material to the players skull.

--- a/src/main/resources/commands.yml
+++ b/src/main/resources/commands.yml
@@ -83,15 +83,13 @@ commands:
         header: '&7[&f%amount%&7] &c&lAdmins'
         # Placeholders will parse in terms of the player.
         section: '&7- &f<player> {server_formatted}'
-      mod:
-        permission: "leaf.rank.mod"
-        header: '&7[&f%amount%&7] &c&lMods'
-        # Placeholders will parse in terms of the player.
+      moderator:
+        permission: "leaf.rank.moderator"
+        header: '&7[&f%amount%&7] &a&lMods'
         section: '&7- &f<player> {server_formatted}'
-      help:
+      helper:
         permission: "leaf.rank.helper"
-        header: '&7[&f%amount%&7] &c&lHelpers'
-        # Placeholders will parse in terms of the player.
+        header: '&7[&f%amount%&7] &b&lHelpers'
         section: '&7- &f<player> {server_formatted}'
 
   reload:
@@ -226,12 +224,13 @@ commands:
     # %page_amount% : The amount of pages they can see.Trfor (int i = 0; i< n;i++){
     footer: '&8&m&l---------------------'
 
-  amenu:
+  admin_menu:
     type: "inventory"
     enabled: true
-    name: "amenu"
-    permission: "leaf.amenu"
-    error: "{error_colour}Error occurred when opening admin menu."
+    name: "adminmenu"
+    aliases: [ "amenu" ]
+    permission: "leaf.adminmenu"
+    error: "{error_colour}Error occurred when opening the admin menu."
     inventory:
       size: GENERIC_9X6
       title: "&8&lAdmin Menu"
@@ -244,19 +243,22 @@ commands:
           lore:
             - "&7Welcome Admin!"
         "19":
-          material: "black_banner"
+          material: "spyglass"
           name: "&a&lToggle Spy"
+          lore:
+            - "&7Click to toggle the ability to veiw global messages."
           commands:
             # Only works with commands registered with this plugin.
             - "togglespy"
         "21":
           material: "name_tag"
-          name: "&a&lShow Stafflist"
+          name: "&a&lShow Staff List"
+          lore:
+            - "&7CLick to veiw the list of staff."
           commands:
-            # Only works with commands registered with this plugin.
             - "stafflist"
 
-  inventory:
+  menu:
     type: "inventory"
     enabled: true
     name: "menu"
@@ -268,27 +270,32 @@ commands:
         "top":
           material: GRAY_STAINED_GLASS_PANE
         "center0":
+          # Sets the material to the players skull.
           skull: "<player>"
           name: "&a&l<player>"
           lore:
             - "&7You are amazing!"
         "8":
           material: "end_crystal"
-          name: "&a&lFriends Settings"
+          name: "&a&lFriend Settings"
+          lore:
+            - "&7Click to run the command &f/settings"
           commands:
             # Only works with commands registered with this plugin.
             - "friends settings"
         "10":
           material: "writable_book"
-          name: "&a&lView your friends list"
+          name: "&a&lFriends list"
+          lore:
+            - "&7Click to run the command &f/friends list"
           commands:
-            # Only works with commands registered with this plugin.
             - "friends list"
         "center1":
           material: "Paper"
-          name: "&a&lRun Command &f/servers"
+          name: "&a&lServer List"
+          lore:
+            - "&7Click to run the command &f/servers"
           commands:
-            # Only works with commands registered with this plugin.
             - "servers"
 
   teleport:


### PR DESCRIPTION
Extended output of "stafflist" to include two more op/admin roles and added permissions to define the two roles.

Added new command "amenu" to show how to make an admin only menu. Included is the permission needed to use the command to view the menu as well as samples for admin only commands.

Extended the default inventory "menu" to include "friends list" and "friends settings" as options to better show how to pass arguments with commands via the gui and give new server owners a good springboard for setting up a menu.