### PR TITLE
[fix] fix typo in default database.yml

### DIFF
--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -22,7 +22,7 @@ type: SQLITE
 # # MONGO DATABASE
 # # This type of database saves data to the cloud.
 # connection_string: "connectionString"
-# database_same: "Database"
+# database_name: "Database"
 
 # ✜ Settings ✜
 # The maximum amount of history that will

--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -22,7 +22,7 @@ type: SQLITE
 # # MONGO DATABASE
 # # This type of database saves data to the cloud.
 # connection_string: "connectionString"
-# database_name: "Database"
+# database_name: "leaf"
 
 # ✜ Settings ✜
 # The maximum amount of history that will

--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -22,7 +22,7 @@ type: SQLITE
 # # MONGO DATABASE
 # # This type of database saves data to the cloud.
 # connection_string: "connectionString"
-# database_name: "leaf"
+# database_name: "Leaf"
 
 # ✜ Settings ✜
 # The maximum amount of history that will


### PR DESCRIPTION
The entry "database_name" is called "database_same" in the default database.yml file generated when the plugin first launches. This PR fixes this.

Also sets the example database name to "Leaf" because "Database" is not viable as a name.

Closes #78 